### PR TITLE
add making path if not exist

### DIFF
--- a/pytorch/preprocess.py
+++ b/pytorch/preprocess.py
@@ -102,7 +102,9 @@ def nii2jpg_label(img_path, output_root):
         #color = np.concatenate([c0,c0,c255], 2)
         #color_img = color_img.astype(np.float32) + color
         #color_img = (color_img / color_img.max()) *255
-
+        if not os.path.exists(output_path):
+            os.makedirs(output_path)
+            
         cv2.imwrite(filename, gray_img)
 
 


### PR DESCRIPTION
The current code only works if the path for the new image exists. CV2 imwrite will not work if the path does not exist.
I added the path creation if not exist to generate the required folders for cv2 imwrite.