### PR TITLE
Update mkdirs

### DIFF
--- a/pytorch/preprocess.py
+++ b/pytorch/preprocess.py
@@ -45,11 +45,11 @@ def nii2jpg_img(img_path, output_root):
     img_name = (img_path.split('/')[-1]).split('.')[0]
     output_path = os.path.join(output_root, img_name)
     try:
-        os.mkdir(output_root)
+        os.makedirs(output_root)
     except:
         pass
     try:
-        os.mkdir(output_path)
+        os.makedirs(output_path)
     except:
         pass
     img = nib.load(img_path)


### PR DESCRIPTION
makedirs() creates all the intermediate directories if they don't exist.
mkdir() can create a single sub-directory, and will throw an exception if intermediate directories that don't exist are specified.
The current implementation with mkdir will not work if the intermediate data folder does not exist.
Alternatively, the makedirs() will generate intermediate folders if needed.